### PR TITLE
feat: time display options

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { URLFormat } from './config'
+import { TimeDisplayOptions, URLFormat } from './config'
 
 const wildcardToRegExp = (s: string): RegExp =>
   new RegExp('^' + s.split(/\*+/).map(regExpEscape).join('.*') + '$')
@@ -142,4 +142,27 @@ export const applyTimeRange = async (
   return await chrome.tabs.update(tab.id, { url: url.toString() })
 }
 
-export const displayTime = (t: number): string => moment(t).format('lll')
+const displayDateTimeFormat = (opts: TimeDisplayOptions) => {
+  return new Intl.DateTimeFormat(
+    opts.locale !== null ? opts.locale : undefined,
+    {
+      timeZone: opts.timeZone !== null ? opts.timeZone : undefined,
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    }
+  )
+}
+
+export const displayTimeRange = (
+  range: TimeRange,
+  opts: TimeDisplayOptions
+): string => {
+  const format = displayDateTimeFormat(opts)
+  const start = format.format(range.start)
+  const end = format.format(range.end)
+  return `${start} - ${end}`
+}
+
+export const displayTimeZone = (opts: TimeDisplayOptions): string => {
+  return displayDateTimeFormat(opts).resolvedOptions().timeZone
+}


### PR DESCRIPTION
## Overview

This feature allows users to customize the time zone and format of the time display on the popup. The setting can be specified both for globally or for any urlFormat. See config spec in `src/lib/config.ts` for details.

Related #1 

## Examples

### Default (no additional configuration)

The locale and time zone set as the browser's default are used always.
(The locale `ja-JP` and the time zone `Asia/Tokyo` are used as the browser's default in the following screen shots.)

<img width="452" alt="スクリーンショット 2022-05-01 18 07 58" src="https://user-images.githubusercontent.com/12710854/166139697-b7ab72a1-1a69-45b6-a1bf-a5e18c0ea501.png">


### Global setting

```yaml
configVersion: 1

timeDisplayOptions:
  locale: 'en-US' # Specify a string with a BCP 47 language tag.
  timeZone: UTC   # Specify `UTC` or an IANA time zone name (e.g. `America/Los_Angeles`).

urlFormats:
  ... snip ...
```

The locale `en-US` and the time zone `UTC` are used always.

<img width="452" alt="スクリーンショット 2022-05-01 18 09 14" src="https://user-images.githubusercontent.com/12710854/166139805-23931d89-b237-467d-b819-63573cb69f8f.png">

### Setting for any specific page (urlFormat)

```yaml
configVersion: 1

timeDisplayOptions:
  locale: 'en-US'
  timeZone: UTC

urlFormats:
  - urlWildcard: '*.example.com/*'
    timeDisplayOptions:
      timeZone: America/Los_Angeles
  ... snip ...
```

The locale `en-US` and the time zone `UTC` are used always, except when any page matching `*.example.com/*` is active.
The locale `en-US` and the time zone `America/Los_Angeles` are used when any page matching `*.example.com/*` is active.

<img width="452" alt="スクリーンショット 2022-05-01 18 11 26" src="https://user-images.githubusercontent.com/12710854/166139882-ae4d46bb-582a-4e3f-8277-77dd4724e811.png">

### Use the browser's default for any specific page (urlFormat)

```yaml
configVersion: 1

timeDisplayOptions:
  locale: 'en-US'
  timeZone: UTC

urlFormats:
  - urlWildcard: '*.example.com/*'
    timeDisplayOptions:
      locale: # Leave empty or `null` to use browser's default
      timeZone: America/Los_Angeles
  ... snip ...
```

The locale `en-US` and the time zone `UTC` are used always, except when any page matching `*.example.com/*` is active.
The locale set as the browser's default and the time zone `America/Los_Angeles` are used when any page matching `*.example.com/*` is active.

<img width="452" alt="スクリーンショット 2022-05-01 18 14 01" src="https://user-images.githubusercontent.com/12710854/166139887-bf13a554-ee97-4ba6-85fc-3c1cd323713e.png">