### PR TITLE
fix: version format & hydration mismatches

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -26,8 +26,8 @@ jobs:
       - name: Get manifest versions
         id: versions
         run: |
-          PREV_VERSION=$(git show HEAD~1:manifest.json 2>/dev/null | jq -r '.version' || echo "")
-          CURR_VERSION=$(jq -r '.version' manifest.json 2>/dev/null || echo "")
+          PREV_VERSION=$(git show HEAD~1:manifest.json 2>/dev/null | jq -r '.version_name' || echo "")
+          CURR_VERSION=$(jq -r '.version_name' manifest.json 2>/dev/null || echo "")
           echo "previous=$PREV_VERSION" >> $GITHUB_OUTPUT
           echo "current=$CURR_VERSION" >> $GITHUB_OUTPUT
 
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -68,7 +68,7 @@ jobs:
         run: |
           BETA=$(node -e "const semver=require('semver'); console.log(semver.inc('${{ needs.version.outputs.current }}','prerelease','beta'))")
           TAG=v$BETA
-          jq ".version = \"${BETA}\"" manifest.json > tmp.json && mv tmp.json manifest.json
+          jq ".version_name = \"${BETA}\"" manifest.json > tmp.json && mv tmp.json manifest.json
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -am "chore: bump to ${BETA}"
@@ -108,7 +108,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Timerange Clipboard",
-  "version": "1.1.1-beta.0",
+  "version_name": "1.1.1-beta.0",
   "description": "Extension to copy and paste URL parameters in any format representing time ranges.",
   "icons": {
     "16": "assets/icon/active16.png",

--- a/src/pages/options.tsx
+++ b/src/pages/options.tsx
@@ -49,7 +49,7 @@ const Options = (): React.JSX.Element => {
           <Heading as="h1" size="4xl">
             Timerange Clipboard
           </Heading>
-          <Text>Version: {VERSION}</Text>
+          <Text>{`Version: ${VERSION}`}</Text>
         </VStack>
         {/* {mode == 'form'
           ? configYaml && (

--- a/src/pages/popup.tsx
+++ b/src/pages/popup.tsx
@@ -172,7 +172,7 @@ const Popup = (): React.JSX.Element => {
             <BsClock style={{ marginRight: '0.25rem' }} />
             {displayTimeZone(activeTimeDisplayOptions)}
           </Text>
-          <Text>Timerange Clipboard v{VERSION}</Text>
+          <Text>{`Timerange Clipboard v${VERSION}`}</Text>
         </Stack>
         <Spacer />
         <Group>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const semver = require('semver')
 const ESLintPlugin = require('eslint-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
@@ -43,8 +44,8 @@ module.exports = (_env, argv) => {
 
   const manifest = require('./manifest.json')
   const versionOverride = process.env.CI
-    ? manifest.version
-    : manifest.version + '+local'
+    ? manifest.version_name
+    : manifest.version_name + '+local'
   const definitions = {
     VERSION: JSON.stringify(versionOverride),
   }
@@ -142,7 +143,8 @@ module.exports = (_env, argv) => {
               from: 'manifest.json',
               transform(buf) {
                 const manifest = JSON.parse(buf.toString('utf-8'))
-                manifest.version = versionOverride
+                manifest.version = semver.coerce(versionOverride).version
+                manifest.version_name = versionOverride
                 return Buffer.from(JSON.stringify(manifest, null, 2), 'utf-8')
               },
             },


### PR DESCRIPTION
* [fix: invalid version format for google chrome](https://github.com/HirokiCHIBA/timerange-clipboard/pull/10/commits/065e3346c04fb11fcb980d214e30a9e73ca051ff)
  * Since `version` in manifest.json is not SemVer and does not support pre-release versions or build metadata, use `version_name` to manage SemVer. [ref](https://developer.chrome.com/docs/extensions/reference/manifest/version)
  * For now, `version` is set by cutting out the SemVer up to the patch version.
* [fix: hydration mismatches by text nodes](https://github.com/HirokiCHIBA/timerange-clipboard/pull/10/commits/c4fa882b7d4ecb5ae91dc41ae5c7bc2a0500c753)
  * Fixed hydration mismatch caused by text nodes being split by the `VERSION` variable.